### PR TITLE
Fix typo in pretrain error message

### DIFF
--- a/pretrain_logic.py
+++ b/pretrain_logic.py
@@ -138,7 +138,7 @@ def run_all():
         else:
             log_to_statusbox("[Pretrain] No Sakura_as_mother.json found — skipping audio pretraining.")
     except:
-        log_to_statusbox(f"[Prtrain] Failed to inject birth certificate and/or voice samples.")
+        log_to_statusbox(f"[Pretrain] Failed to inject birth certificate and/or voice samples.")
 
         # Reindex memory directly (no subprocess)
         log_to_statusbox("[Pretrain] Reindexing memory map...")


### PR DESCRIPTION
## Summary
- correct spelling of the Pretrain tag in error logging

## Testing
- `python -m py_compile pretrain_logic.py`


------
https://chatgpt.com/codex/tasks/task_e_68911eca0480832cb9977370edfc2f08