### PR TITLE
Use context manager when loading fragments

### DIFF
--- a/emotion_engine.py
+++ b/emotion_engine.py
@@ -19,11 +19,12 @@ SLIDERS = [
 ]
 
 def load_fragments(path):
-    return [
-        json.load(open(f, "r"))
-        for f in sorted(Path(path).glob("frag_*.json"))
-        if f.is_file() and f.suffix == ".json"
-    ]
+    fragments = []
+    for f in sorted(Path(path).glob("frag_*.json")):
+        if f.is_file() and f.suffix == ".json":
+            with open(f, "r") as handle:
+                fragments.append(json.load(handle))
+    return fragments
 
 def calculate_emotion_state(fragments):
     totals = {k: 0.0 for k in SLIDERS}


### PR DESCRIPTION
## Summary
- Properly close fragment files by loading them within a context manager

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68911ed054c8832ca9fd582a9c23e706