### PR TITLE
Add Seedling Transformer for emergent symbol clustering

### DIFF
--- a/tests/test_seedling_transformer.py
+++ b/tests/test_seedling_transformer.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from transformers.seedling_transformer import SeedlingTransformer
+
+
+def test_germinate_clusters_and_seeds():
+    symbols = ["alpha", "atom", "beta", "bloom"]
+    transformer = SeedlingTransformer(seed=0)
+    result = transformer.germinate(symbols)
+
+    clusters = result["clusters"]
+    seeds = result["seeds"]
+
+    assert set(clusters.keys()) == {"a", "b"}
+    assert set(seeds.keys()) == {"a", "b"}
+    assert seeds["a"].startswith("a")
+    assert seeds["b"].startswith("b")

--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -5,6 +5,7 @@ from .fractal_multidimensional_transformers import (
     FractalTransformer,
     load_precision_profile,
 )
+from .seedling_transformer import SeedlingTransformer
 try:  # pragma: no cover - optional dependency
     from .QTransformer import QTransformer
 except Exception:  # pragma: no cover
@@ -20,6 +21,7 @@ __all__ = [
     "HeuristicMirrorTransformer",
     "FractalTransformer",
     "load_precision_profile",
+    "SeedlingTransformer",
     "QTransformer",
     "HindsightTransformer",
     "ShadowTransformer",

--- a/transformers/seedling_transformer.py
+++ b/transformers/seedling_transformer.py
@@ -1,0 +1,67 @@
+"""seedling_transformer.py
+
+Seedling Transformer
+--------------------
+Early-stage ideation — pre-conceptual thinking.  Takes messy symbolic
+fragments and attempts to coax nascent structures.  It may produce nonsense or
+unexpected gems, serving as a germination stage rather than optimisation.
+"""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from typing import Dict, Iterable, List
+
+from gui_hook import log_to_statusbox
+
+
+class SeedlingTransformer:
+    """Germinate new symbolic seeds from noisy fragments.
+
+    Parameters
+    ----------
+    seed:
+        Optional random seed to make behaviour deterministic for tests.
+    """
+
+    def __init__(self, seed: int | None = None) -> None:
+        self._rng = random.Random(seed)
+
+    # ----------------------------------------------------------------- public
+    def germinate(self, symbols: Iterable[str]) -> Dict[str, Dict[str, List[str]]]:
+        """Form clusters and generate emergent seed strings.
+
+        Parameters
+        ----------
+        symbols:
+            Iterable of raw symbol fragments.
+
+        Returns
+        -------
+        dict
+            Mapping with ``clusters`` and ``seeds`` keys. ``clusters`` maps the
+            cluster key to the list of original symbols while ``seeds`` maps the
+            same key to a newly combined fragment.
+        """
+
+        symbol_list = [str(s) for s in symbols]
+
+        clusters: Dict[str, List[str]] = defaultdict(list)
+        for sym in symbol_list:
+            key = sym[0] if sym else self._rng.choice("abcdefghijklmnopqrstuvwxyz")
+            clusters[key].append(sym)
+
+        seeds: Dict[str, str] = {}
+        for key, group in clusters.items():
+            if not group:
+                continue
+            shuffled = group[:]
+            self._rng.shuffle(shuffled)
+            parts = [g[: max(1, len(g) // 2)] for g in shuffled[:2]]
+            seeds[key] = "".join(parts)
+
+        log_to_statusbox(
+            f"[Seedling] Germinated {len(seeds)} seeds from {len(symbol_list)} symbols."
+        )
+        return {"clusters": dict(clusters), "seeds": seeds}


### PR DESCRIPTION
## Summary
- introduce `SeedlingTransformer` to coax clusters and proto-symbols from noisy inputs
- expose transformer in package exports and document behavior
- add tests exercising seed generation and cluster formation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3277c639c832cb1d15fdb30b2f2c2