### PR TITLE
Add memetic layer for event superposition

### DIFF
--- a/memetic_layer.py
+++ b/memetic_layer.py
@@ -1,0 +1,81 @@
+"""Memetic Layer handling event superposition and entanglement."""
+
+from dataclasses import dataclass
+from typing import List, Dict, Tuple, Optional
+import random
+
+
+@dataclass
+class Event:
+    actors: List[str]
+    symbols: List[str]
+    affordances: List[str]
+    stakes: str
+    phase: str
+    amplitude: float = 1.0
+    collapse_rule: str = "max"
+
+
+class MemeticLayer:
+    """Simple qualitative event superposition tracker."""
+
+    def __init__(self):
+        # context -> list of (Event, weight)
+        self.superpositions: Dict[str, List[Tuple[Event, float]]] = {}
+        # (id(event_a), id(event_b)) -> correlation strength
+        self.entanglements: Dict[Tuple[int, int], float] = {}
+
+    # --- Superposition management -------------------------------------------------
+    def add_event(self, context: str, event: Event, weight: float = 1.0) -> None:
+        """Insert an event into a context superposition.
+
+        We store raw weights here; normalization happens lazily before
+        qualitative operations like ``drift`` or ``collapse``. This allows the
+        caller to add events with the intended relative amplitudes without
+        earlier entries being rescaled on every insertion.
+        """
+        self.superpositions.setdefault(context, []).append((event, weight))
+
+    def _normalize(self, context: str) -> None:
+        events = self.superpositions.get(context, [])
+        total = sum(w for _, w in events)
+        if total <= 0:
+            return
+        self.superpositions[context] = [(e, w / total) for e, w in events]
+
+    def drift(self, context: str, amount: float = 0.1) -> None:
+        """Heuristically nudge weights within a context."""
+        self._normalize(context)
+        events = self.superpositions.get(context, [])
+        if not events:
+            return
+        new_weights = []
+        for _, w in events:
+            delta = random.uniform(-amount, amount)
+            new_weights.append(max(0.0, w + delta))
+        total = sum(new_weights)
+        if total == 0:
+            new_weights = [1.0 / len(events) for _ in events]
+        else:
+            new_weights = [w / total for w in new_weights]
+        self.superpositions[context] = [(ev, w) for (ev, _), w in zip(events, new_weights)]
+
+    def collapse(self, context: str) -> Optional[Event]:
+        """Collapse the context to the highest-weighted event."""
+        self._normalize(context)
+        events = self.superpositions.get(context, [])
+        if not events:
+            return None
+        chosen, _ = max(events, key=lambda ew: ew[1])
+        self.superpositions[context] = [(chosen, 1.0)]
+        return chosen
+
+    # --- Entanglement management --------------------------------------------------
+    def entangle(self, event_a: Event, event_b: Event, strength: float = 1.0) -> None:
+        """Track correlation between two events."""
+        key = (id(event_a), id(event_b))
+        self.entanglements[key] = strength
+
+    def get_entanglement(self, event_a: Event, event_b: Event) -> Optional[float]:
+        key = (id(event_a), id(event_b))
+        return self.entanglements.get(key)

--- a/tests/test_memetic_layer.py
+++ b/tests/test_memetic_layer.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from memetic_layer import Event, MemeticLayer
+
+
+def _sample_event(name: str) -> Event:
+    return Event(
+        actors=[name],
+        symbols=[f"{name}_symbol"],
+        affordances=["act"],
+        stakes="medium",
+        phase="observation",
+    )
+
+
+def test_superposition_collapse():
+    layer = MemeticLayer()
+    e1 = _sample_event("A")
+    e2 = _sample_event("B")
+    layer.add_event("story", e1, weight=0.4)
+    layer.add_event("story", e2, weight=0.6)
+    chosen = layer.collapse("story")
+    assert chosen is e2
+    ctx = layer.superpositions["story"]
+    assert len(ctx) == 1 and ctx[0][0] is e2 and pytest.approx(ctx[0][1], rel=1e-6) == 1.0
+
+
+def test_entanglement_tracking():
+    layer = MemeticLayer()
+    e1 = _sample_event("A")
+    e2 = _sample_event("B")
+    layer.entangle(e1, e2, 0.7)
+    assert layer.get_entanglement(e1, e2) == pytest.approx(0.7)
+
+
+def test_drift_normalizes():
+    layer = MemeticLayer()
+    e1 = _sample_event("A")
+    e2 = _sample_event("B")
+    layer.add_event("story", e1, weight=0.5)
+    layer.add_event("story", e2, weight=0.5)
+    layer.drift("story", amount=0.3)
+    weights = [w for _, w in layer.superpositions["story"]]
+    assert pytest.approx(sum(weights), rel=1e-6) == 1.0
+    assert all(w >= 0 for w in weights)


### PR DESCRIPTION
## Summary
- implement `Event` data class and `MemeticLayer` for qualitative event superposition and entanglement tracking
- expose drift and collapse operations for narrative weighting
- add unit tests for superposition, entanglement, and drift normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44c012d78832ca8d2905ac0ffef39