### PR TITLE
Enhance raw file scanning roots

### DIFF
--- a/raw_file_manager.py
+++ b/raw_file_manager.py
@@ -6,6 +6,7 @@ import json
 import wave
 import contextlib
 import sys
+import itertools
 from datetime import datetime, timezone
 from pathlib import Path
 from PIL import Image
@@ -28,6 +29,18 @@ def load_config():
         return json.load(f)
 
 config = load_config()
+
+def _load_path_from_config(key):
+    value = config.get(key)
+    if not value:
+        return None
+    try:
+        return Path(value).expanduser()
+    except TypeError:
+        return None
+
+book_folder_path = _load_path_from_config("book_folder_path")
+music_folder_path = _load_path_from_config("music_folder_path")
 
 def get_child():
     log_to_statusbox("[RawFileManager] Attempting to retrieve 'child'...")
@@ -163,82 +176,141 @@ def fragment_audio(audio_path, transformer):
 
 def self_read_and_train():
     child = get_child()
-    root = Path.home() / "Projects" / "Project Inazuma"
-    history = set(load_history(child))
+    default_root = Path.home() / "Projects" / "Project Inazuma"
+
+    raw_history = load_history(child)
+    history = {entry for entry in raw_history if "/" in entry}
+    legacy_history = {entry for entry in raw_history if "/" not in entry}
     new_fragments = []
 
+    roots = []
+    seen_roots = set()
+
+    def add_root(path, audio_only=False):
+        try:
+            resolved = path.resolve()
+        except FileNotFoundError:
+            return
+        if resolved in seen_roots:
+            return
+        seen_roots.add(resolved)
+        roots.append((path, audio_only))
+
+    if default_root.exists():
+        add_root(default_root, audio_only=False)
+    else:
+        log_to_statusbox(f"[SelfRead] Project root not found: {default_root}")
+
+    if book_folder_path and book_folder_path.exists():
+        add_root(book_folder_path, audio_only=False)
+    elif book_folder_path:
+        log_to_statusbox(f"[SelfRead] Book folder not found: {book_folder_path}")
+
+    if music_folder_path and music_folder_path.exists():
+        add_root(music_folder_path, audio_only=True)
+    elif music_folder_path:
+        log_to_statusbox(f"[SelfRead] Music folder not found: {music_folder_path}")
+
     log_to_statusbox(f"[SelfRead] Child set to: {child}")
-    log_to_statusbox(f"[SelfRead] Scanning: {root}")
-    log_to_statusbox(f"[SelfRead] Loaded {len(history)} previously seen files.")
+    if roots:
+        log_to_statusbox("[SelfRead] Roots to scan: " + ", ".join(str(path) for path, _ in roots))
+    else:
+        log_to_statusbox("[SelfRead] No available roots to scan.")
+        return
+    log_to_statusbox(f"[SelfRead] Loaded {len(history) + len(legacy_history)} previously seen files.")
 
     transformer = FractalTransformer()
     count = 0
 
-    for path in root.rglob("*"):
-        if not path.is_file():
-            continue
+    audio_patterns = ("*.wav", "*.mp3")
 
-        log_to_statusbox(f"[SelfRead] Inspecting: {path}")
+    for base_root, audio_only in roots:
+        log_to_statusbox(f"[SelfRead] Scanning: {base_root}")
 
-        if path.name in history:
-            log_to_statusbox(f"[SelfRead] SKIP {path.name} — already seen.")
-            continue
+        if audio_only:
+            file_iter = itertools.chain.from_iterable(base_root.rglob(pattern) for pattern in audio_patterns)
+        else:
+            file_iter = base_root.rglob("*")
 
-        if not is_readable_file(path):
-            log_to_statusbox(f"[SelfRead] SKIP {path.name} — not a supported format or too large.")
-            continue
-
-        ext = path.suffix.lower()
-        log_to_statusbox(f"[SelfRead] PROCESSING {path.name} (.{ext})")
-
-        try:
-            if ext in ALLOWED_TEXT_EXT:
-                with open(path, "r", encoding="utf-8", errors="ignore") as f:
-                    text = f.read()
-                result = fragment_text(text, path.name, transformer)
-
-            elif ext in [".png", ".jpg", ".jpeg"]:
-                result = fragment_image(path, transformer)
-
-            elif ext in [".wav"]:
-                result = fragment_audio(path, transformer)
-
-            elif ext in [".mp3"]:
-                log_to_statusbox(f"[SelfRead] NOTE: {path.name} is mp3 — audio_digest handles those. Skipping.")
+        for path in file_iter:
+            if not path.is_file():
                 continue
 
-            else:
-                log_to_statusbox(f"[SelfRead] SKIP {path.name} — unrecognized extension.")
+            try:
+                relative_path = path.relative_to(base_root)
+            except ValueError:
+                relative_path = path.name
+
+            rel_str = relative_path.as_posix() if isinstance(relative_path, Path) else str(relative_path)
+            history_key = f"{base_root.name}/{rel_str}"
+
+            log_to_statusbox(f"[SelfRead] Inspecting: {path}")
+
+            if history_key in history or (base_root == default_root and path.name in legacy_history):
+                log_to_statusbox(f"[SelfRead] SKIP {path.name} — already seen.")
                 continue
 
-            if result:
-                for frag in result:
-                    frag_id = f"frag_selfread_{abs(hash(frag['summary'])) % 10**12}"
-                    frag["id"] = frag_id
+            if not is_readable_file(path):
+                log_to_statusbox(f"[SelfRead] SKIP {path.name} — not a supported format or too large.")
+                continue
 
-                    frag_path = Path("AI_Children") / child / "memory" / "fragments" / f"{frag_id}.json"
-                    frag_path.parent.mkdir(parents=True, exist_ok=True)
+            ext = path.suffix.lower()
+            log_to_statusbox(f"[SelfRead] PROCESSING {path.name} (.{ext})")
 
-                    with open(frag_path, "w", encoding="utf-8") as f:
-                        json.dump(frag, f, indent=4)
+            try:
+                if ext in ALLOWED_TEXT_EXT:
+                    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                        text = f.read()
+                    result = fragment_text(text, path.name, transformer)
 
-                    log_to_statusbox(f"[SelfRead] + Fragment saved: {frag_id} from {path.name}")
-                    log_reflection(child, frag)
-                    new_fragments.append(frag)
+                elif ext in [".png", ".jpg", ".jpeg"]:
+                    result = fragment_image(path, transformer)
 
-                history.add(path.name)
-                count += len(result)
+                elif ext in [".wav"]:
+                    result = fragment_audio(path, transformer)
 
-        except Exception as e:
-            log_to_statusbox(f"[SelfRead] ERROR processing {path.name}: {e}")
+                elif ext in [".mp3"]:
+                    log_to_statusbox(f"[SelfRead] NOTE: {path.name} is mp3 — audio_digest handles those. Skipping.")
+                    continue
+
+                else:
+                    log_to_statusbox(f"[SelfRead] SKIP {path.name} — unrecognized extension.")
+                    continue
+
+                if result:
+                    for frag in result:
+                        frag_id = f"frag_selfread_{abs(hash(frag['summary'])) % 10**12}"
+                        frag["id"] = frag_id
+
+                        frag_path = Path("AI_Children") / child / "memory" / "fragments" / f"{frag_id}.json"
+                        frag_path.parent.mkdir(parents=True, exist_ok=True)
+
+                        with open(frag_path, "w", encoding="utf-8") as f:
+                            json.dump(frag, f, indent=4)
+
+                        log_to_statusbox(f"[SelfRead] + Fragment saved: {frag_id} from {path.name}")
+                        log_reflection(child, frag)
+                        new_fragments.append(frag)
+
+                    if base_root == default_root:
+                        legacy_history.discard(path.name)
+                    history.add(history_key)
+                    count += len(result)
+
+            except Exception as e:
+                log_to_statusbox(f"[SelfRead] ERROR processing {path.name}: {e}")
+
+            if count >= FRAG_LIMIT:
+                log_to_statusbox("[SelfRead] Fragment limit reached — stopping scan.")
+                break
 
         if count >= FRAG_LIMIT:
-            log_to_statusbox("[SelfRead] Fragment limit reached — stopping scan.")
             break
 
-    save_history(child, list(history))
+    combined_history = list(history.union(legacy_history))
+    save_history(child, combined_history)
     log_to_statusbox(f"[SelfRead] Done. {count} new fragments saved.")
-    
+
     if count > 0:
         log_to_statusbox("[SelfRead] Calling training pipeline...")
         os.system("python train_fragments.py")


### PR DESCRIPTION
## Summary
- load optional book and music library paths from configuration
- scan multiple roots, restricting music traversal to audio files and logging each root
- namespace read-history keys across roots while maintaining compatibility with existing records

## Testing
- python -m compileall raw_file_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc3920e38832c96380ef328cee38c