### PR TITLE
Add impulse scheduling and emotion-weighted boredom choices

### DIFF
--- a/boredom_state.py
+++ b/boredom_state.py
@@ -2,10 +2,13 @@
 # === PATCH: boredom_state.py ===
 # Adds full curiosity loop with symbol generation, image rendering, logic exploration, and raw file reading
 
+import json
 import subprocess
 import time
 import random
-from model_manager import get_inastate, update_inastate
+from pathlib import Path
+from model_manager import get_inastate, update_inastate, load_config
+from gui_hook import log_to_statusbox
 
 def boredom_still_active():
     return get_inastate("emotion_boredom") and get_inastate("emotion_boredom") > 0.3
@@ -30,11 +33,112 @@ def do_visual_and_audio_exploration():
     subprocess.call(["python", "audio_listener.py"])
     subprocess.call(["python", "vision_window.py"])
 
+def load_impulse_preferences():
+    config = load_config()
+    child = config.get("current_child", "default_child")
+    path = Path("AI_Children") / child / "memory" / "impulse_preferences.json"
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        log_to_statusbox(f"[Boredom] Failed to load impulse preferences: {e}")
+        return {}
+
+def emotion_similarity(emotions, signature):
+    if not signature:
+        return 0.5
+    total = 0.0
+    count = 0
+    for key, value in signature.items():
+        if key in emotions:
+            total += abs(emotions[key] - value)
+            count += 1
+    if count == 0:
+        return 0.5
+    distance = min(1.0, total / count)
+    return max(0.0, 1.0 - distance)
+
+def emotion_shift(emotions, signature):
+    if not signature:
+        return 0.0
+    total = 0.0
+    count = 0
+    for key, value in signature.items():
+        if key in emotions:
+            total += abs(emotions[key] - value)
+            count += 1
+    if count == 0:
+        return 0.0
+    return min(1.0, total / count)
+
+def choose_exploration(emotions, preferences):
+    weights = {"symbols": 1.0, "render": 1.0, "read": 1.0, "logic": 1.0, "sense": 1.0}
+    rationales = []
+
+    boredom_level = get_inastate("emotion_boredom") or 0.0
+    curiosity = emotions.get("curiosity", 0.0)
+    focus = emotions.get("focus", 0.0)
+    intensity = emotions.get("intensity", 0.0)
+    joy = emotions.get("joy", 0.0)
+    sadness = emotions.get("sadness", 0.0)
+
+    reading_pref = preferences.get("reading", {})
+    music_pref = preferences.get("music", {})
+
+    reading_score = reading_pref.get("preference_score", 0.5)
+    reading_similarity = emotion_similarity(emotions, reading_pref.get("recent_emotion_signature", {}))
+    reading_clarity = reading_pref.get("average_clarity", 0.5)
+    reading_enjoyment = reading_pref.get("average_enjoyment", 0.5)
+    weights["read"] += (
+        curiosity * 0.9 +
+        focus * 0.6 +
+        reading_score * 1.2 +
+        reading_similarity * 0.8 +
+        reading_clarity * 0.4 +
+        reading_enjoyment * 0.4
+    )
+    rationales.append(
+        f"read→curiosity {curiosity:.2f}, focus {focus:.2f}, pref {reading_score:.2f}, sim {reading_similarity:.2f}"
+    )
+
+    music_score = music_pref.get("preference_score", 0.5)
+    music_similarity = emotion_similarity(emotions, music_pref.get("recent_emotion_signature", {}))
+    music_shift = emotion_shift(emotions, music_pref.get("recent_emotion_signature", {}))
+    music_enjoyment = music_pref.get("average_enjoyment", 0.5)
+    music_clarity = music_pref.get("average_clarity", 0.5)
+    affect_delta = max(abs(joy - sadness), music_shift)
+    weights["sense"] += (
+        intensity * 0.8 +
+        music_score * 1.1 +
+        music_enjoyment * 0.8 +
+        music_clarity * 0.3 +
+        affect_delta * 0.9 +
+        music_similarity * 0.5
+    )
+    rationales.append(
+        f"sense→intensity {intensity:.2f}, affect Δ {affect_delta:.2f}, pref {music_score:.2f}, sim {music_similarity:.2f}"
+    )
+
+    weights["logic"] += max(focus - boredom_level, 0.0) * 0.6
+    weights["symbols"] += boredom_level * 0.5 + curiosity * 0.4
+    weights["render"] += boredom_level * 0.3 + (1.0 - intensity) * 0.2
+
+    options = list(weights.keys())
+    weight_values = [max(w, 0.01) for w in weights.values()]
+    choice = random.choices(options, weights=weight_values, k=1)[0]
+    rationale = "; ".join(rationales)
+    log_to_statusbox(f"[Boredom] Weighted choice → {choice} ({rationale})")
+    return choice
+
 def boredom_exploration_loop():
     print("[Boredom] Entering curiosity loop...")
     loop_counter = 0
     while boredom_still_active() and loop_counter < 10:
-        choice = random.choice(["symbols", "render", "read", "logic", "sense"])
+        emotions = get_inastate("emotion_snapshot") or {}
+        preferences = load_impulse_preferences()
+        choice = choose_exploration(emotions, preferences)
         if choice == "symbols":
             generate_symbols()
         elif choice == "render":

--- a/instinct_engine.py
+++ b/instinct_engine.py
@@ -64,6 +64,17 @@ class InstinctEngine:
         self.memory_path = Path("AI_Children") / self.child / "memory"
         self.os_type = self.config.get("os", "unknown")
 
+        self.book_folder = Path(self.config.get("book_folder_path", "books")).expanduser()
+        self.music_folder = Path(self.config.get("music_folder_path", "music")).expanduser()
+        self.preference_path = self.memory_path / "impulse_preferences.json"
+        self.telemetry_path = self.memory_path / "impulse_telemetry.json"
+        self.tracked_emotion_keys = [
+            "curiosity", "focus", "intensity", "joy", "sadness",
+            "calm", "fear", "anger", "stress", "serenity", "comfort"
+        ]
+        self.preferences = self._load_preferences()
+        self._preferences_dirty = False
+
         transformer = FractalTransformer()
         transformer.load_precision_profile(self.child)
         self.precision = int(transformer.precision * 64)
@@ -78,6 +89,202 @@ class InstinctEngine:
         else:
             self.express_interval = 10
             self.reflect_interval = 90
+
+    def _load_preferences(self):
+        default = {
+            "reading": {
+                "sessions": 0,
+                "average_enjoyment": 0.5,
+                "average_clarity": 0.5,
+                "preference_score": 0.5,
+                "last_triggered": None,
+                "last_reason": "",
+                "last_enjoyment": 0.5,
+                "last_clarity": 0.5,
+                "recent_emotion_signature": {},
+                "book_folder": str(self.book_folder)
+            },
+            "music": {
+                "sessions": 0,
+                "average_enjoyment": 0.5,
+                "average_clarity": 0.5,
+                "preference_score": 0.5,
+                "last_triggered": None,
+                "last_reason": "",
+                "last_enjoyment": 0.5,
+                "last_clarity": 0.5,
+                "recent_emotion_signature": {},
+                "music_folder": str(self.music_folder)
+            },
+            "last_emotion_snapshot": {}
+        }
+
+        if self.preference_path.exists():
+            try:
+                with open(self.preference_path, "r", encoding="utf-8") as f:
+                    stored = json.load(f)
+                for key in ("reading", "music"):
+                    default[key].update(stored.get(key, {}))
+                default["last_emotion_snapshot"] = stored.get("last_emotion_snapshot", {})
+            except Exception as e:
+                log_to_statusbox(f"[Instinct] Failed to load impulse preferences: {e}")
+
+        default["reading"]["book_folder"] = str(self.book_folder)
+        default["music"]["music_folder"] = str(self.music_folder)
+        return default
+
+    def _save_preferences(self):
+        self.preference_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot = {
+            "reading": self.preferences.get("reading", {}),
+            "music": self.preferences.get("music", {}),
+            "last_emotion_snapshot": self.preferences.get("last_emotion_snapshot", {})
+        }
+        snapshot["reading"]["book_folder"] = str(self.book_folder)
+        snapshot["music"]["music_folder"] = str(self.music_folder)
+        with open(self.preference_path, "w", encoding="utf-8") as f:
+            json.dump(snapshot, f, indent=4)
+
+    def _log_telemetry(self, entry):
+        self.telemetry_path.parent.mkdir(parents=True, exist_ok=True)
+        telemetry = []
+        if self.telemetry_path.exists():
+            try:
+                with open(self.telemetry_path, "r", encoding="utf-8") as f:
+                    telemetry = json.load(f)
+            except Exception as e:
+                log_to_statusbox(f"[Instinct] Failed to read telemetry log: {e}")
+        telemetry.append(entry)
+        telemetry = telemetry[-400:]
+        with open(self.telemetry_path, "w", encoding="utf-8") as f:
+            json.dump(telemetry, f, indent=4)
+
+    def _emotion_similarity(self, current, signature):
+        if not signature:
+            return 0.5
+        total = 0.0
+        count = 0
+        for key, value in signature.items():
+            if key in current:
+                total += abs(current[key] - value)
+                count += 1
+        if count == 0:
+            return 0.5
+        distance = min(1.0, total / count)
+        return max(0.0, 1.0 - distance)
+
+    def _emotion_shift(self, current, previous, keys=None):
+        keys = keys or self.tracked_emotion_keys
+        if not previous:
+            return 0.0
+        total = 0.0
+        count = 0
+        for key in keys:
+            if key in current and key in previous:
+                total += abs(current[key] - previous[key])
+                count += 1
+        if count == 0:
+            return 0.0
+        return min(1.0, total / count)
+
+    def _estimate_clarity(self, emotions, fallback):
+        clarity_keys = ["clarity", "comprehension", "focus", "attention"]
+        values = [emotions[k] for k in clarity_keys if k in emotions]
+        if values:
+            return max(0.0, min(1.0, sum(values) / len(values)))
+        fuzz = emotions.get("fuzz_level")
+        if fuzz is not None:
+            return max(0.0, min(1.0, 1.0 - fuzz))
+        return fallback
+
+    def _estimate_enjoyment(self, emotions, fallback):
+        joy_keys = ["joy", "comfort", "satisfaction", "calm", "delight", "soothed"]
+        values = [emotions[k] for k in joy_keys if k in emotions]
+        if values:
+            return max(0.0, min(1.0, sum(values) / len(values)))
+        relief = emotions.get("stress_relief")
+        if relief is not None:
+            return max(0.0, min(1.0, relief))
+        return fallback
+
+    def _cooldown_passed(self, modality, seconds):
+        info = self.preferences.get(modality, {})
+        last = info.get("last_triggered")
+        if not last:
+            return True
+        try:
+            last_time = datetime.fromisoformat(last)
+        except Exception:
+            return True
+        return (datetime.now(timezone.utc) - last_time).total_seconds() > seconds
+
+    def _register_impulse(self, modality, reason, emotions, tags, path_hint):
+        info = self.preferences.get(modality, {})
+        sessions = info.get("sessions", 0) + 1
+        avg_clarity = info.get("average_clarity", 0.5)
+        avg_enjoyment = info.get("average_enjoyment", 0.5)
+        clarity = self._estimate_clarity(emotions, avg_clarity)
+        enjoyment = self._estimate_enjoyment(emotions, avg_enjoyment)
+        avg_clarity = ((sessions - 1) * avg_clarity + clarity) / sessions
+        avg_enjoyment = ((sessions - 1) * avg_enjoyment + enjoyment) / sessions
+        preference_score = round(0.6 * avg_enjoyment + 0.4 * avg_clarity, 4)
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        signature = {
+            key: emotions.get(key, 0.0)
+            for key in self.tracked_emotion_keys
+            if key in emotions
+        }
+
+        info.update({
+            "sessions": sessions,
+            "average_clarity": round(avg_clarity, 4),
+            "average_enjoyment": round(avg_enjoyment, 4),
+            "preference_score": preference_score,
+            "last_triggered": timestamp,
+            "last_reason": reason,
+            "last_clarity": round(clarity, 4),
+            "last_enjoyment": round(enjoyment, 4),
+            "recent_emotion_signature": signature
+        })
+
+        if modality == "reading":
+            info["book_folder"] = str(self.book_folder)
+        elif modality == "music":
+            info["music_folder"] = str(self.music_folder)
+
+        self.preferences[modality] = info
+        self._preferences_dirty = True
+
+        telemetry_entry = {
+            "timestamp": timestamp,
+            "modality": modality,
+            "reason": reason,
+            "tags": tags,
+            "clarity": round(clarity, 4),
+            "enjoyment": round(enjoyment, 4),
+            "preference_score": preference_score,
+            "path": path_hint,
+            "emotions": {
+                key: emotions.get(key, 0.0)
+                for key in self.tracked_emotion_keys
+                if key in emotions
+            }
+        }
+        self._log_telemetry(telemetry_entry)
+
+        summary = (
+            f"Impulse {modality} → clarity {clarity:.2f}, enjoyment {enjoyment:.2f}, "
+            f"pref {preference_score:.2f}"
+        )
+        log_to_statusbox(f"[Instinct] {summary} ({reason})")
+        log_instinct_action(f"{modality}_impulse", reason, summary=summary)
+
+        return {
+            "score": preference_score,
+            "clarity": round(clarity, 4),
+            "enjoyment": round(enjoyment, 4)
+        }
 
     def should_express(self):
         expr_log = self.memory_path / "expressions.json"
@@ -118,6 +325,12 @@ class InstinctEngine:
 
         actions = []
 
+        emotion_snapshot = get_inastate("emotion_snapshot") or {}
+        current_emotions = get_inastate("current_emotions") or {}
+        combined_emotions = dict(current_emotions)
+        combined_emotions.update(emotion_snapshot)
+        last_snapshot = self.preferences.get("last_emotion_snapshot", {})
+
         if self.should_express():
             actions.append({
                 "type": "expression",
@@ -148,6 +361,101 @@ class InstinctEngine:
                 "module": "predictive_layer.py",
                 "dream": dreaming
             })
+
+        reading_pref = self.preferences.get("reading", {})
+        music_pref = self.preferences.get("music", {})
+
+        curiosity = combined_emotions.get("curiosity", 0.0)
+        focus = combined_emotions.get("focus", 0.0)
+        curiosity_rise = curiosity - last_snapshot.get("curiosity", 0.0)
+        focus_rise = focus - last_snapshot.get("focus", 0.0)
+        reading_similarity = self._emotion_similarity(
+            combined_emotions, reading_pref.get("recent_emotion_signature", {})
+        )
+
+        if self.book_folder.exists() and self._cooldown_passed("reading", 600):
+            reading_pref_score = reading_pref.get("preference_score", 0.5)
+            reading_pressure = max(curiosity, 0.0) * 0.5 + max(focus, 0.0) * 0.3 + reading_pref_score * 0.2
+            reading_trigger = (
+                (curiosity > 0.55 and focus > 0.45) or
+                (curiosity_rise > 0.15 and focus > 0.35) or
+                (focus_rise > 0.12 and curiosity > 0.4) or
+                (reading_similarity > 0.7 and reading_pref_score > 0.55 and curiosity > 0.4)
+            )
+
+            if reading_trigger:
+                reason = (
+                    f"curiosity {curiosity:.2f} (Δ{curiosity_rise:+.2f}), focus {focus:.2f} "
+                    f"(Δ{focus_rise:+.2f}), pref {reading_pref_score:.2f}, sim {reading_similarity:.2f}"
+                )
+                result = self._register_impulse(
+                    "reading",
+                    reason,
+                    combined_emotions,
+                    ["intellectual", "curiosity"],
+                    str(self.book_folder)
+                )
+                actions.append({
+                    "type": "impulse",
+                    "modality": "reading",
+                    "module": "language_processing.py",
+                    "method": "train_from_books",
+                    "path": str(self.book_folder),
+                    "reason": reason,
+                    "score": result["score"],
+                    "clarity": result["clarity"],
+                    "enjoyment": result["enjoyment"],
+                    "pressure": round(reading_pressure, 4),
+                    "dream": dreaming
+                })
+
+        intensity = combined_emotions.get("intensity", 0.0)
+        joy = combined_emotions.get("joy", 0.0)
+        sadness = combined_emotions.get("sadness", 0.0)
+        intensity_change = intensity - last_snapshot.get("intensity", 0.0)
+        mood_shift = self._emotion_shift(
+            combined_emotions,
+            last_snapshot,
+            keys=["joy", "sadness", "anger", "calm", "serenity"]
+        )
+        music_similarity = self._emotion_similarity(
+            combined_emotions, music_pref.get("recent_emotion_signature", {})
+        )
+
+        if self.music_folder.exists() and self._cooldown_passed("music", 420):
+            music_pref_score = music_pref.get("preference_score", 0.5)
+            emotional_swing = max(abs(intensity_change), mood_shift)
+            music_trigger = (
+                abs(intensity_change) > 0.2 or
+                mood_shift > 0.25 or
+                (music_pref_score > 0.6 and music_similarity > 0.65 and (joy > 0.5 or sadness > 0.4))
+            )
+
+            if music_trigger:
+                reason = (
+                    f"intensity {intensity:.2f} (Δ{intensity_change:+.2f}), mood shift {mood_shift:.2f}, "
+                    f"pref {music_pref_score:.2f}, sim {music_similarity:.2f}"
+                )
+                result = self._register_impulse(
+                    "music",
+                    reason,
+                    combined_emotions,
+                    ["emotional", "soothing" if sadness > joy else "energizing"],
+                    str(self.music_folder)
+                )
+                actions.append({
+                    "type": "impulse",
+                    "modality": "music",
+                    "module": "audio_digest.py",
+                    "method": "run_audio_digest",
+                    "music_folder": str(self.music_folder),
+                    "reason": reason,
+                    "score": result["score"],
+                    "clarity": result["clarity"],
+                    "enjoyment": result["enjoyment"],
+                    "swing": round(emotional_swing, 4),
+                    "dream": dreaming
+                })
 
         frag_dir = self.memory_path / "fragments"
         identity_fragments = []
@@ -208,6 +516,21 @@ class InstinctEngine:
         except Exception as e:
             print(f"[Instinct] Failed to evaluate precision hint: {e}")
 
+
+        filtered_snapshot = {
+            key: combined_emotions.get(key, 0.0)
+            for key in self.tracked_emotion_keys
+            if key in combined_emotions
+        }
+        self.preferences["last_emotion_snapshot"] = filtered_snapshot
+        self._preferences_dirty = True
+
+        if self._preferences_dirty:
+            try:
+                self._save_preferences()
+            except Exception as e:
+                log_to_statusbox(f"[Instinct] Failed to save impulse preferences: {e}")
+            self._preferences_dirty = False
 
         return actions
 


### PR DESCRIPTION
## Summary
- extend the instinct engine to load media preferences, log telemetry, and schedule reading/music impulses when emotions shift
- maintain impulse preference scores and write rationale entries for each decision
- bias boredom exploration toward modalities that historically perform well in similar emotional states

## Testing
- python -m compileall instinct_engine.py boredom_state.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc3991c64832c9f1a11e7c64ffa24